### PR TITLE
Make search query timezone agnostic

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function getPullRequests(username) {
     deferred = q.defer();
 
     options = {
-        q: 'created:2016-09-30T00:00:00-12:00..2016-10-31T23:59:59-12:00+type:pr+is:public+author:' + username
+        q: 'created:2016-09-30T00:00:00..2016-10-31T23:59:59+type:pr+is:public+author:' + username
     };
 
     github.search.issues(options, function(err, res) {


### PR DESCRIPTION
The checker should return all pull requests made regardless of timezones since the Hacktoberfest website was renewed for 2016 

Refer to jenkoian/hacktoberfest-checker#24