### PR TITLE
Improve Dockerfile to cache node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM node:6
 
 WORKDIR /app
-COPY . /app
 
 RUN useradd -ms /bin/bash octocat
 RUN chown octocat:octocat /app
 USER octocat
 
-RUN npm install
+# With this npm install will only ever be run when building if the application's package.json changes!
+COPY package.json /app
+# Copy bower.json as well otherwise post install will fail
+COPY bower.json /app
+
+RUN npm install --production
+
+COPY . /app
 
 EXPOSE 5000
 


### PR DESCRIPTION
There are a lots of way to improve the node usage with Docker, one of them is to cache the node_modules folder so that npm install runs only if the package.json changes

see 
[https://nodesource.com/blog/8-protips-to-start-killing-it-when-dockerizing-node-js/#protip3startcachingnode_modules](https://nodesource.com/blog/8-protips-to-start-killing-it-when-dockerizing-node-js/#protip3startcachingnode_modules) for more details