### PR TITLE
Refactor the front end, components should be easier to test now

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,28 +1,152 @@
 $(document).ready(function() {
-
-    $('input[name=username]').focus();
-
-    $('form').on('submit', function(e) {
-        var name = $('input[name=username]').val();
-
-        if(name == '') {
-            $('#results').html('<div class="row"><div class="large-12 columns"><h2>Username cannot be blank.</h2></div></div>');
-        }
-        else {
-            $('#results').html('<div class="row"><div class="large-12 columns"><h2><img src="/img/ajax-loader.gif" alt="loading" /></h2></div></div>');
-            $.get('/?username=' + name, function (html) {
-                $('#results').html(html);
-                if (window.history && window.history.replaceState) {
-                  history.replaceState({}, name, '?username=' + name);
-                }
-            });
-        }
-        e.preventDefault();
-    });
-
-    //start fetching new issue once the page is loaded
-    $('#open-issues').html('<div class="row"><div class="large-12 columns"><h2><img src="/img/ajax-loader.gif" alt="loading" /></h2></div></div>');
-    $.get('/issues', function (html) {
-        $('#open-issues').html(html);
-    });
+    new HacktoberfestChecker().constructor();
 });
+
+function HacktoberfestChecker() {
+    // DOM nodes cache
+    this.username = $('input[name=username]');
+    this.openIssues = $('#open-issues');
+    this.form = $('form');
+    this.results = $('#results');
+    // some configurable error messages
+    this.errors = {
+        emptyUsername: "Username cannot be blank.",
+        API: {
+            issue: "An error occurred while fetching new issues, have you set your github token? ",
+            username: "An error occurred while fetching issue for the given username, have you set your github token? "
+        }
+    };
+    //the path for the spinner
+    this.loader = "/img/ajax-loader.gif";
+}
+/**
+ * in the constructor we'll everything that needs to fire when we new this object up
+ */
+HacktoberfestChecker.prototype.constructor = function() {
+    this.setFocus();
+    this.bindEvents();
+    this.getNewIssues();
+};
+/**
+ * the bind events function can be extended as the app grows
+ */
+HacktoberfestChecker.prototype.bindEvents = function() {
+    this.form.on("submit", this.getUsernameIssues.bind(this));
+};
+/**
+ * Set the focus on the username field
+ */
+HacktoberfestChecker.prototype.setFocus = function() {
+    this.username.focus();
+};
+/**
+ * API call to the backend to featch new issues
+ */
+HacktoberfestChecker.prototype.getNewIssues = function() {
+    this.openIssues.html(this.makeSpinner());
+    $.ajax({
+        url: '/issues',
+        type: "GET",
+        success: this.newIssuesSuccess.bind(this),
+        //new: add error handler in case of failure during the API call
+        error: this.newIssuesError.bind(this)
+    });
+};
+/**
+ * In case of success during API call, display the HTML
+ */
+HacktoberfestChecker.prototype.newIssuesSuccess = function(html) {
+    this.openIssues.html(html);
+};
+/**
+ * In case of an error during API call, display an error message
+ */
+HacktoberfestChecker.prototype.newIssuesError = function(html) {
+    this.openIssues.html(this.makeError(this.errors.API.issue));
+};
+
+HacktoberfestChecker.prototype.getUsernameIssues = function(e) {
+    if (e) {
+        e.preventDefault();
+    }
+    var name = this.getName();
+
+    if (!name) {
+        this.results.html(this.makeError(this.errors.emptyUsername));
+        return;
+    }
+    this.results.html(this.makeSpinner());
+
+    $.ajax({
+        url: '/?username=' + name,
+        type: "GET",
+        success: this.usernameIssuesSuccess.bind(this),
+        //new: add error handler in case of failure during the API call
+        error: this.usernameIssuesError.bind(this),
+        always: this.updateHistory.apply(this, [name])
+    });
+
+};
+
+/**
+ * In case of success during API call, display the HTML
+ */
+HacktoberfestChecker.prototype.usernameIssuesSuccess = function(html) {
+    this.results.html(html);
+};
+/**
+ * In case of an error during API call, display an error message
+ */
+HacktoberfestChecker.prototype.usernameIssuesError = function(html) {
+    this.results.html(this.makeError(this.errors.API.username));
+};
+
+HacktoberfestChecker.prototype.getName = function() {
+    return this.username.val() || false;
+};
+/**
+ * HTML Helper makeSpinner
+ * create the necessary HTML to show the spinner using fluent syntax
+ */
+HacktoberfestChecker.prototype.makeSpinner = function() {
+    return $("<div/>", {
+        class: "row"
+    }).append(
+        $("<div/>", {
+            class: "large-12 columns"
+        }).append(
+            $("<h2/>").append(
+                $("<img/>", {
+                    src: this.loader,
+                    alt: "loading"
+                })
+            )
+        )
+    );
+};
+/**
+ * HTML Helper makeSpinner
+ * create the necessary HTML to show an error message using fluent syntax
+ */
+HacktoberfestChecker.prototype.makeError = function(error) {
+    return $("<div/>", {
+        class: "row"
+    }).append(
+        $("<div/>", {
+            class: "large-12 columns"
+        }).append(
+            $("<h2/>", {
+                text: error
+            })
+        )
+    );
+};
+/**
+ * History state helper, checks if the replaceState is available
+ * before updating the username in the query string.
+ */
+HacktoberfestChecker.prototype.updateHistory = function(name) {
+    if (window.history && window.history.replaceState) {
+        history.replaceState({}, name, '?username=' + name);
+    }
+};


### PR DESCRIPTION
After discussing some refactoring in #16 before adding tests I've decided to start from the front end that it's easier to de-couple.

I went for plain ol' JavaScript, no ES6/TypeScript so it will be easier for other developer to understand what's going on and there is no need to know ES6/TS

If/when we're all happy with this refactor I can start to add tests!