### PR TITLE
Add repo languages

### DIFF
--- a/views/partials/issues.hbs
+++ b/views/partials/issues.hbs
@@ -28,6 +28,12 @@
         <div class="large-12 columns">
             <br />
             <p>{{{this.description}}}</p>
+            {{#if this.language}}
+                <br />
+                <p>
+                    Language: <span class="label round">{{this.language}}</span>
+                </p>
+            {{/if}}
         </div>
     </div>
     {{/each}}

--- a/views/partials/issues.hbs
+++ b/views/partials/issues.hbs
@@ -9,7 +9,7 @@
                 {{#if this.language}}
                     <span class="label round">{{this.language}}</span>
                 {{/if}}
-</h5>
+            </h5>
         </div>
     </div>
     <div class="row">

--- a/views/partials/issues.hbs
+++ b/views/partials/issues.hbs
@@ -5,7 +5,11 @@
     {{#each issues}}
     <div class="row">
         <div class="large-12 columns issue">
-            <h5><a href="{{this.repo_url}}">{{this.repo_name}}</a></h5>
+            <h5><a href="{{this.repo_url}}">{{this.repo_name}}</a>
+                {{#if this.language}}
+                    <span class="label round">{{this.language}}</span>
+                {{/if}}
+</h5>
         </div>
     </div>
     <div class="row">
@@ -28,12 +32,6 @@
         <div class="large-12 columns">
             <br />
             <p>{{{this.description}}}</p>
-            {{#if this.language}}
-                <br />
-                <p>
-                    Language: <span class="label round">{{this.language}}</span>
-                </p>
-            {{/if}}
         </div>
     </div>
     {{/each}}


### PR DESCRIPTION
As discussed in #51 I've added the language to the repo list

now the first limitation is: the library used to interact with GitHub when calling the repo info is returning just one language (probably the most used) instead the API exposed by github returns all the languages used in the repo [https://developer.github.com/v3/repos/#list-languages](https://developer.github.com/v3/repos/#list-languages)

I think ATM will do fine, but the back-end need some restructure for both maintainability and testing