### PR TITLE
Frontend tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Small app to see if you have fulfilled the requirements for a Hacktoberfest t-shirt",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node ./node_modules/jest/bin/jest ",
+    "test:watch": "node ./node_modules/jest/bin/jest --watch",
+    "test:coverage": "node ./node_modules/jest/bin/jest --coverage",
+    "test:updateSnapshot": "node ./node_modules/jest/bin/jest --updateSnapshot",
+    "test:full": "node ./node_modules/jest/bin/jest --watch --coverage",
     "postinstall": "node ./node_modules/bower/bin/bower install"
   },
   "keywords": [
@@ -18,9 +22,13 @@
     "express-handlebars": "^2.0.1",
     "github": "^0.2.4",
     "helper-timeago": "^0.1.0",
+    "jest": "^16.0.1",
     "lodash": "^3.10.1",
+    "marked": "^0.3.6",
     "memory-cache": "^0.1.4",
-    "q": "^1.4.1",
-    "marked": "^0.3.6"
-  }
+    "q": "^1.4.1"
+  },
+    "jest": {
+        "preprocessorIgnorePatterns": ["node_modules", "bower_components"]
+    }
 }

--- a/public/__test__/__snapshots__/script.test.js.snap
+++ b/public/__test__/__snapshots__/script.test.js.snap
@@ -1,0 +1,46 @@
+exports[`API October PRs error message 1`] = `"<div class=\"row\"><div class=\"large-12 columns\"><h2>An error occurred while fetching new issues, have you set your github token? </h2></div></div>"`;
+
+exports[`API October PRs success message 1`] = `"Testing!"`;
+
+exports[`API Username PRs error message 1`] = `"<div class=\"row\"><div class=\"large-12 columns\"><h2>An error occurred while fetching new issues, have you set your github token? </h2></div></div>"`;
+
+exports[`API Username PRs success message 1`] = `"<div class=\"row\"><div class=\"large-12 columns\"><h2>An error occurred while fetching new issues, have you set your github token? </h2></div></div>"`;
+
+exports[`HTML Error markup is approved markup 1`] = `"<div class=\"large-12 columns\"><h2></h2></div>"`;
+
+exports[`HTML Spinner markup is approved markup 1`] = `"<div class=\"large-12 columns\"><h2><img src=\"/img/ajax-loader.gif\" alt=\"loading\"></h2></div>"`;
+
+exports[`HacktoberfestChecker default properies are set 1`] = `
+Array [
+  Object {
+    "username": Object {
+      "isjQuery": true,
+      "length": 1,
+    },
+  },
+  Object {
+    "openIssues": Object {
+      "isjQuery": true,
+      "length": 1,
+    },
+  },
+  Object {
+    "form": Object {
+      "isjQuery": true,
+      "length": 1,
+    },
+  },
+  Object {
+    "results": Object {
+      "isjQuery": true,
+      "length": 1,
+    },
+  },
+  Object {
+    "errors": "{\"emptyUsername\":\"Username cannot be blank.\",\"API\":{\"issue\":\"An error occurred while fetching new issues, have you set your github token? \",\"username\":\"An error occurred while fetching issues for the given username, have you set your github token? \"}}",
+  },
+  Object {
+    "loader": "\"/img/ajax-loader.gif\"",
+  },
+]
+`;

--- a/public/__test__/__snapshots__/script.test.js.snap
+++ b/public/__test__/__snapshots__/script.test.js.snap
@@ -10,7 +10,7 @@ exports[`HTML Error markup is approved markup 1`] = `"<div class=\"large-12 colu
 
 exports[`HTML Spinner markup is approved markup 1`] = `"<div class=\"large-12 columns\"><h2><img src=\"/img/ajax-loader.gif\" alt=\"loading\"></h2></div>"`;
 
-exports[`HacktoberfestChecker default properies are set 1`] = `
+exports[`HacktoberfestChecker default properties are set 1`] = `
 Array [
   Object {
     "username": Object {

--- a/public/__test__/script.test.js
+++ b/public/__test__/script.test.js
@@ -1,3 +1,5 @@
+const html = require('fs').readFileSync('./../views/index.hbs').toString();
+document.documentElement.innerHTML = html;
 const HacktoberfestChecker = require("../js/script");
 const $ = require('./../../bower_components/jquery/dist/jquery.min');
 window.$ = $;
@@ -7,9 +9,101 @@ describe('HacktoberfestChecker', function() {
     it('Function Exists', function() {
         expect(typeof HacktoberfestChecker === "function").toBeTruthy();
     });
-    it('Properties are not empty', function() {
-        for (property of Object.getOwnPropertyNames(instance)) {
-            expect(instance[property]).toBeTruthy();
+    it("default properies are set", function() {
+        var objProperties = Object.getOwnPropertyNames(instance);
+        var properties = objProperties.map(function(v) {
+            var out = {};
+            out[v] = instance[v];
+            if (out[v]instanceof $) {
+                out[v] = {
+                    "isjQuery": true,
+                    "length": out[v].length
+                };
+            } else {
+                out[v] = JSON.stringify(out[v]);
+            }
+            return out;
+        });
+        expect(properties).toMatchSnapshot();
+    });
+    it('constructor does not throw errors', function() {
+        try {
+            HacktoberfestChecker.prototype.constructor.call(instance);
+            expect(true).toBeTruthy();
+        } catch (exc) {
+            expect(exc).toBeFalsy();
         }
+    });
+});
+describe('HTML', function() {
+    describe('Error markup', function() {
+        var errorMessage = HacktoberfestChecker.prototype.makeError.call(instance);
+        it('is jQuery Object', function() {
+            expect(errorMessage instanceof $).toBeTruthy();
+        });
+
+        it('is approved markup', function() {
+            expect(errorMessage.html()).toMatchSnapshot();
+        });
+    });
+    describe('Spinner markup', function() {
+        var spinner = HacktoberfestChecker.prototype.makeSpinner.call(instance);
+        it('is jQuery Object', function() {
+            expect(spinner instanceof $).toBeTruthy();
+        });
+
+        it('is approved markup', function() {
+            expect(spinner.html()).toMatchSnapshot();
+        });
+    });
+});
+describe('DOM', function() {
+    describe('username field focus', function() {
+        HacktoberfestChecker.prototype.setFocus.call(instance);
+        it('has focus', function() {
+            expect(instance.username.is(":focus")).toBeTruthy();
+        });
+    });
+    describe('events bind', function() {
+        HacktoberfestChecker.prototype.bindEvents.call(instance);
+        it('submit form', function() {
+            expect($._data(instance.form.get(0), "events").hasOwnProperty("submit")).toBeTruthy();
+        });
+    });
+    describe('get username value', function() {
+        it('if empty is false', function() {
+            instance.username.val("");
+            var emptyUsername = HacktoberfestChecker.prototype.getName.call(instance, "Testing!");
+            expect(emptyUsername).toBeFalsy();
+        });
+        it('if filled is string', function() {
+            var testValue = "Testing!";
+            instance.username.val(testValue);
+            var username = HacktoberfestChecker.prototype.getName.call(instance, "Testing!");
+            expect(username).toBe(testValue);
+        });
+    });
+});
+
+describe('API', function() {
+    describe('October PRs', function() {
+        it("success message", function() {
+            HacktoberfestChecker.prototype.newIssuesSuccess.call(instance, "Testing!");
+            expect(instance.openIssues.html()).toMatchSnapshot();
+        });
+        it("error message", function() {
+            HacktoberfestChecker.prototype.newIssuesError.call(instance);
+            expect(instance.openIssues.html()).toMatchSnapshot();
+        });
+    });
+    describe('Username PRs', function() {
+        it("success message", function() {
+            HacktoberfestChecker.prototype.usernameIssuesSuccess.call(instance, "Testing!");
+            expect(instance.openIssues.html()).toMatchSnapshot();
+        });
+        it("error message", function() {
+            HacktoberfestChecker.prototype.usernameIssuesError.call(instance);
+            expect(instance.openIssues.html()).toMatchSnapshot();
+        });
     });
 });

--- a/public/__test__/script.test.js
+++ b/public/__test__/script.test.js
@@ -1,4 +1,4 @@
-const html = require('fs').readFileSync('./../views/index.hbs').toString();
+const html = require('fs').readFileSync('./views/index.hbs').toString();
 document.documentElement.innerHTML = html;
 const HacktoberfestChecker = require("../js/script");
 const $ = require('./../../bower_components/jquery/dist/jquery.min');
@@ -9,7 +9,7 @@ describe('HacktoberfestChecker', function() {
     it('Function Exists', function() {
         expect(typeof HacktoberfestChecker === "function").toBeTruthy();
     });
-    it("default properies are set", function() {
+    it("default properties are set", function() {
         var objProperties = Object.getOwnPropertyNames(instance);
         var properties = objProperties.map(function(v) {
             var out = {};

--- a/public/__test__/script.test.js
+++ b/public/__test__/script.test.js
@@ -1,0 +1,15 @@
+const HacktoberfestChecker = require("../js/script");
+const $ = require('./../../bower_components/jquery/dist/jquery.min');
+window.$ = $;
+const instance = new HacktoberfestChecker();
+
+describe('HacktoberfestChecker', function() {
+    it('Function Exists', function() {
+        expect(typeof HacktoberfestChecker === "function").toBeTruthy();
+    });
+    it('Properties are not empty', function() {
+        for (property of Object.getOwnPropertyNames(instance)) {
+            expect(instance[property]).toBeTruthy();
+        }
+    });
+});

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,6 +1,10 @@
-$(document).ready(function() {
-    new HacktoberfestChecker().constructor();
-});
+if (typeof module === "object" && typeof module.exports === "object") {
+    module.exports = HacktoberfestChecker;
+} else {
+    $(document).ready(function() {
+        new HacktoberfestChecker().constructor();
+    });
+}
 
 function HacktoberfestChecker() {
     // DOM nodes cache


### PR DESCRIPTION
As discussed in #16 after the refactoring of the front-end JS I've added some tests using [Jest](https://facebook.github.io/jest/) 

The current code coverage is 75-80%

I've added NPM scripts as well:

test:  runs all the test suites (shortcut `npm t`)
test:watch: runs jest in watch mode,
test:coverage: runs jest with the code coverage flag,
test:updateSnapshot: runs jest and updates the stored snapshot,
test:full: runs jest in watch mode with the code coverage flag

once the back-end is refactored as well we can hook up jest to test all that as well