### PR TITLE
Trim username

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -106,7 +106,7 @@ HacktoberfestChecker.prototype.usernameIssuesError = function(html) {
 };
 
 HacktoberfestChecker.prototype.getName = function() {
-    return this.username.val() || false;
+    return this.username.val().trim() || false;
 };
 /**
  * HTML Helper makeSpinner


### PR DESCRIPTION
Removing spaces around the username prevents a duplicate search bar from appearing if the user enters a query of two spaces.