### PR TITLE
Style error messages to have white text

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -100,7 +100,7 @@ HacktoberfestChecker.prototype.makeSpinner = function() {
  * create the necessary HTML to show an error message using fluent syntax
  */
 HacktoberfestChecker.prototype.makeError = function(error) {
-    return $("<div/>").append(
+    return $("<div/>").addClass('white').append(
         $("<h2/>", {
             text: error
         })


### PR DESCRIPTION
Black on blue does not seem to be as friendly as white on blue. This PR tries to follow the style of text I've seen on the front page.