### PR TITLE
Mobile styling

### DIFF
--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -8,7 +8,7 @@
     <h3 class="white"><strong>{{ statement }}</strong></h3>
 
     {{#each prs}}
-      <a href="{{this.url}}" class="center db pa3 bg-white bb br1 w-50 grey dim pointer no-underline {{#if hasHacktoberFestLabel}}b--orange{{/if}}">
+      <a href="{{this.url}}" class="center db pa3 bg-white bb br1 w-75 w-50-ns grey dim pointer no-underline {{#if hasHacktoberFestLabel}}b--orange{{/if}}">
         {{this.repo_name}} - #{{this.title}} ({{this.state}})
       </a>
     {{/each}}


### PR DESCRIPTION
While using the checker on my mobile I noticed that the text detailing my pull request was spilling out of the container. I've increased the width of the container when viewed on a smaller device.

| ![Before](https://user-images.githubusercontent.com/6834105/31053475-ec0b3b16-a695-11e7-8f49-3980415cf51d.png) | ![After](https://user-images.githubusercontent.com/6834105/31053477-ee5ed698-a695-11e7-95af-2d631824ad3c.png) |
|:---:|:---:|
| Before | After |