### PR TITLE
Fixed style for empty user input

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -103,7 +103,7 @@ HacktoberfestChecker.prototype.makeError = function(error) {
     return $('<div/>').append(
         $('<h2/>', {
             text: error,
-            class: "white"
+            class: 'white'
         })
     );
 };

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -102,7 +102,8 @@ HacktoberfestChecker.prototype.makeSpinner = function() {
 HacktoberfestChecker.prototype.makeError = function(error) {
     return $('<div/>').append(
         $('<h2/>', {
-            text: error
+            text: error,
+            class: "white"
         })
     );
 };


### PR DESCRIPTION
Before message "Username cannot be blank." was black and now it's white and following the same style as other errors.
