### PR TITLE
User avatar is now shown for people without PRs

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -4,9 +4,6 @@
  * GET /
  */
 exports.index = (req, res) => {
-    const prs = [];
-    let userImage;
-
     function findPrs(username) {
         const _ = req.app.get('_');
         const q = req.app.get('q');
@@ -18,20 +15,17 @@ exports.index = (req, res) => {
             q: `-label:invalid+created:2017-09-30T00:00:00-12:00..2017-10-31T23:59:59-12:00+type:pr+is:public+author:${username}`
         };
 
-        github.search.issues(options, (err, res) => {
-            if (err) {
-                deferred.reject();
-                return;
-            }
+        q.all([
+            github.search.issues(options),
+            github.users.getForUser({ username })
+        ]).then(gitData => {
+            const foundPrs = gitData[0];
+            const user     = gitData[1];
 
-            userImage = null;
+            const prs = [];
 
-            _.each(res.data.items, event => {
+            _.each(foundPrs.data.items, event => {
                 const repo = event.pull_request.html_url.substring(0, event.pull_request.html_url.search('/pull'));
-
-                if (userImage == null) {
-                    userImage = event.user.avatar_url;
-                }
 
                 const hacktoberFestLabels = _.filter(event.labels, label => label.name.toLowerCase() === 'hacktoberfest');
 
@@ -45,8 +39,10 @@ exports.index = (req, res) => {
 
                 prs.push(returnedEvent);
             });
-
-            deferred.resolve();
+            
+            deferred.resolve({ prs, user });
+        }).catch(err => {
+            deferred.reject(err);
         });
 
         return deferred.promise;
@@ -57,8 +53,8 @@ exports.index = (req, res) => {
         return res.render('index');
     }
 
-    findPrs(req.query.username).then(() => {
-        let length = prs.length;
+    findPrs(req.query.username).then(data => {
+        let length = data.prs.length;
 
         const statements = [
             'It\'s not too late to start!',
@@ -72,17 +68,22 @@ exports.index = (req, res) => {
         if (length > 5) length = 5;
 
         if (req.xhr) {
-            console.log(prs);
-            res.render('partials/prs', {prs, statement: statements[length], userImage, layout: false});
+            res.render('partials/prs', {
+                prs: data.prs,
+                statement: statements[length],
+                userImage: data.user.data.avatar_url,
+                layout: false
+            });
         } else {
-            res.render('index', {
-                prs,
+            data.render('index', {
+                prs: data.prs,
                 statement: statements[length],
                 username: req.query.username,
-                userImage
+                userImage: data.user.data.avatar_url
             });
         }
-    }).catch(() => {
+    }).catch((e) => {
+        console.log(e);
         if (req.xhr) {
             res.render('partials/error', {layout: false});
         } else {

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -82,8 +82,7 @@ exports.index = (req, res) => {
                 userImage: data.user.data.avatar_url
             });
         }
-    }).catch((e) => {
-        console.log(e);
+    }).catch(() => {
         if (req.xhr) {
             res.render('partials/error', {layout: false});
         } else {

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -75,7 +75,7 @@ exports.index = (req, res) => {
                 layout: false
             });
         } else {
-            data.render('index', {
+            res.render('index', {
                 prs: data.prs,
                 statement: statements[length],
                 username: req.query.username,

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -101,7 +101,7 @@ HacktoberfestChecker.prototype.makeSpinner = function() {
  */
 HacktoberfestChecker.prototype.makeError = function(error) {
     return $('<div/>').append(
-        $('<h2/>', {
+        $('<h2 class="orange"/>', {
             text: error
         })
     );

--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -8,29 +8,32 @@
         <h3>{{ statement }}</h3>
     </div>
 
-    <div class="br2 center mt5 shadow-1 overflow-hidden w-50-ns w-80-m w-90">
-        {{#each prs}}
-            <div class="bg-white {{#if this.has_hacktoberfest_label}}hacktoberfest {{/if}}lh-copy pa3 flex bb b--gray">
-                <div class="br-100 h2 mr3 mt1 tc w2">
-                    {{#if this.open}}
-                        <svg aria-hidden="true" fill="#2cbe4e" height="18" version="1.1" viewBox="0 0 12 16" width="24">
-                            <path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path>
-                        </svg>
-                    {{else}}
-                        <svg aria-hidden="true" fill="#6f42c1" height="18" version="1.1" viewBox="0 0 12 16" width="24">
-                            <path fill-rule="evenodd" d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path>
-                        </svg>
-                    {{/if}}
-                </div>
-                <div>
-                    <div class="mid-gray">
-                        <a class="color-inherit fw6 link underline-hover" href="{{ this.user.url }}">{{ this.user.login }}</a>
-                        submitted a pull request
-                        <a class="blue link underline-hover" href="{{ this.url }}">{{ this.repo_name }}#{{ this.number }}</a>
+    {{#if prs.length}}
+        <div class="br2 center mt5 shadow-1 overflow-hidden w-50-ns w-80-m w-90">
+            {{#each prs}}
+                <div class="bg-white {{#if this.has_hacktoberfest_label}}hacktoberfest {{/if}}lh-copy pa3 flex bb b--gray">
+                    <div class="br-100 h2 mr3 mt1 tc w2">
+                        {{#if this.open}}
+                            <svg aria-hidden="true" fill="#2cbe4e" height="18" version="1.1" viewBox="0 0 12 16" width="24">
+                                <path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path>
+                            </svg>
+                        {{else}}
+                            <svg aria-hidden="true" fill="#6f42c1" height="18" version="1.1" viewBox="0 0 12 16" width="24">
+                                <path fill-rule="evenodd" d="M10 7c-.73 0-1.38.41-1.73 1.02V8C7.22 7.98 6 7.64 5.14 6.98c-.75-.58-1.5-1.61-1.89-2.44A1.993 1.993 0 0 0 2 .99C.89.99 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2a1.993 1.993 0 0 0 1-3.72V7.67c.67.7 1.44 1.27 2.3 1.69.86.42 2.03.63 2.97.64v-.02c.36.61 1 1.02 1.73 1.02 1.11 0 2-.89 2-2 0-1.11-.89-2-2-2zm-6.8 6c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm8 6c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path>
+                            </svg>
+                        {{/if}}
                     </div>
-                    <div class="light-silver">{{ this.title }}</div>
+                    <div>
+                        <div class="mid-gray">
+                            <a class="color-inherit fw6 link underline-hover" href="{{ this.user.url }}">{{ this.user.login }}</a>
+                            submitted a pull request
+                            <a class="blue link underline-hover" href="{{ this.url }}">{{ this.repo_name }}#{{ this.number }}</a>
+                        </div>
+                        <div class="light-silver">{{ this.title }}</div>
+                    </div>
                 </div>
-            </div>
-        {{/each}} 
-    </div>
+            {{/each}}
+        </div>
+    {{/if}}
 {{/exists}}
+


### PR DESCRIPTION
# Fixes :shipit: :shipit: :shipit:
- https://github.com/jenkoian/hacktoberfest-checker/issues/140


# Summary :1st_place_medal: :1st_place_medal: :1st_place_medal:
This pull request will allow the web interface to show data about the user, which currently is only used for the avatar.
Previous method was by getting the avatar from the pull requests, but if none are found the user avatar would not be shown.
The `findPrs` function is now a bit more generalized by returning the prs and the user data as resolved promise parameters, rather than variables defined inside the request.

Some suggestions would be to generalize the `findPrs` even further by moving it out of the request (thus easing the load on the app each request) and possibly exporting it as well.