### PR TITLE
Add link to github.com/username on picture

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -73,8 +73,9 @@ exports.index = (req, res) => {
 
         if (req.xhr) {
             console.log(prs);
-            res.render('partials/prs', {prs, statement: statements[length], userImage, layout: false});
+            res.render('partials/prs', {prs, statement: statements[length], username: req.query.username, userImage, layout: false});
         } else {
+
             res.render('index', {
                 prs,
                 statement: statements[length],

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -75,7 +75,6 @@ exports.index = (req, res) => {
             console.log(prs);
             res.render('partials/prs', {prs, statement: statements[length], username: req.query.username, userImage, layout: false});
         } else {
-
             res.render('index', {
                 prs,
                 statement: statements[length],

--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -1,6 +1,8 @@
 {{#exists prs}}
     {{#if userImage}}
+      <a href = "https://github.com/{{username}}">
         <img class="tc br-100 w4" src="{{userImage}}"/>
+      </a>
     {{/if}}
 
 

--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -1,7 +1,7 @@
 {{#exists prs}}
     <div class="tc white">
         {{#if userImage}}
-            <a href = "https://github.com/{{username}}">
+            <a href = "https://github.com/{{username}}" target="_blank">
                 <img class="tc br-100 w4" src="{{userImage}}"/>
             </a>
         {{/if}}


### PR DESCRIPTION
# Fixes :shipit: :shipit: :shipit:
Nothing in particular, just an enhancement. Searched a friend and tried to click their picture to get to their page, figured it was in the spirit of the event to make that happen.

(possibly https://github.com/jenkoian/hacktoberfest-checker/issues/128)


# Summary :1st_place_medal: :1st_place_medal: :1st_place_medal:
Adds a link to the searched user's github page to the their profile picture that appears after searching.
