### PR TITLE
Add word break to PR item

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -31,3 +31,7 @@ h1 {
   flex-grow: 1;
   flex-shrink: 0;
 }
+
+.pr-item {
+  word-break: break-word;  
+}

--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -18,7 +18,7 @@
     {{#if prs.length}}
         <div class="br2 center mt3 shadow-1 overflow-hidden w-50-ns w-80-m w-90">
             {{#each prs}}
-                <div class="bg-white {{#if this.has_hacktoberfest_label}}hacktoberfest {{/if}}lh-copy pa3 flex bb b--gray">
+                <div class="bg-white {{#if this.has_hacktoberfest_label}}hacktoberfest {{/if}}lh-copy pa3 flex bb b--gray pr-item">
                     <div class="br-100 h2 mr3 mt1 tc w2">
                         {{#if this.open}}
                             <svg aria-hidden="true" fill="#2cbe4e" height="18" version="1.1" viewBox="0 0 12 16" width="24">


### PR DESCRIPTION
Changes: Add word break to PR item

Note: In `tachyons`, this property is removed.

Screenshots for the change:

Before | After
| - | - 
![image](https://user-images.githubusercontent.com/4408379/31268675-18350548-aa86-11e7-89fe-97a19f7d3f86.png) | ![image](https://user-images.githubusercontent.com/4408379/31268680-1e990b3c-aa86-11e7-8078-276cf82a0d06.png)

