### PR TITLE
 Move form input down a little bit so the check button isn't overlapped

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -32,6 +32,10 @@ h1 {
   flex-shrink: 0;
 }
 
+.username-form {
+  padding: 20px 0 0;
+}
+
 .pr-item {
-  word-break: break-word;  
+  word-break: break-word;
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -32,10 +32,6 @@ h1 {
   flex-shrink: 0;
 }
 
-.username-form {
-  padding: 20px 0 0;
-}
-
 .pr-item {
   word-break: break-word;
 }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,6 +1,6 @@
 ﻿<h1 class="f1 f-6-ns orange tc"><a class="orange no-underline" href="/">Hacktoberfest Checker</a></h1>
 
-<div class="tc">
+<div class="tc username-form">
     <form action="/" class="center h2 w-30-ns w-60-m w-80 flex" method="get">
         <input class="bn br--left br1 ph2 flex-auto" type="text" name="username" placeholder="GitHub username" value="{{ username }}">
         <button class="bg-orange bn br--right br1 pv0 ph3 pointer white" type="submit">Check</button>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,6 +1,6 @@
 ﻿<h1 class="f1 f-6-ns orange tc"><a class="orange no-underline" href="/">Hacktoberfest Checker</a></h1>
 
-<div class="tc username-form">
+<div class="tc pt4">
     <form action="/" class="center h2 w-30-ns w-60-m w-80 flex" method="get">
         <input class="bn br--left br1 ph2 flex-auto" type="text" name="username" placeholder="GitHub username" value="{{ username }}">
         <button class="bg-orange bn br--right br1 pv0 ph3 pointer white" type="submit">Check</button>


### PR DESCRIPTION
Changes: Pad username form down so that at 440px wide the check button isn't obscured by the "fork me on github" link

Screenshots for the change:

Before:

![image](https://user-images.githubusercontent.com/1711610/31276307-1999e540-aa93-11e7-96db-172c7c5218b1.png)

After:

![image](https://user-images.githubusercontent.com/1711610/31276311-1ec5db1e-aa93-11e7-8e49-324e4e3366bb.png)
