### PR TITLE
Switch to Yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,6 @@
 npm-debug.log
 node_modules
 
-# Lock files
-yarn.lock
-package-lock.json
-
 # API keys
 .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER octocat
 # With this npm install will only ever be run when building if the application's package.json changes!
 COPY package.json /app
 
-RUN npm install --production
+RUN npm install -g yarn && yarn install --production
 
 COPY . /app
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Happy hacking!
    * Windows (cmd.exe): `set GITHUB_TOKEN=YOUR TOKEN`
    * Windows (PowerShell): `$env:GITHUB_TOKEN=YOUR TOKEN`
 
-* `$ npm install`
+* `$ yarn install`
 
-* `$ npm start`
+* `$ yarn start`
 
 * Point browser to [localhost:5000](http://localhost:5000)
 


### PR DESCRIPTION
Changes: Use `yarn` in README and Docker, since it is mainly used and remove lock files in `.gitignore`.

