### PR TITLE
Add link to hacktoberfest issues

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -122,6 +122,7 @@ exports.index = (req, res) => {
         if (req.query['plain-data']) {
             res.render('partials/prs', {
                 prs: data.prs,
+                isNotComplete: data.prs.length < 4,
                 statement: statements[length],
                 username: req.query.username,
                 userImage: data.user.data.avatar_url,
@@ -130,6 +131,7 @@ exports.index = (req, res) => {
         } else {
             res.render('index', {
                 prs: data.prs,
+                isNotComplete: data.prs.length < 4,
                 statement: statements[length],
                 username: req.query.username,
                 userImage: data.user.data.avatar_url

--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -15,6 +15,14 @@
         </div>
     </div>
 
+    {{#if isNotComplete }} 
+        <div class="flex flex-wrap justify-center content-center">
+            <div class="light-gray">
+                Look at the following <a href="https://github.com/search?q=label:hacktoberfest+state:open+type:issue" class="light-gray" target="_blank">issues</a> and get hacking!</a>
+            </div>
+        </div>
+    {{/if}}
+
     {{#if prs.length}}
         <div class="br2 center mt3 shadow-1 overflow-hidden w-50-ns w-80-m w-90">
             {{#each prs}}


### PR DESCRIPTION
Fixes issue #187 

Changes: Adds a isNotComplete boolean to the rendered payload and displays a link to the GitHub Hacktoberfest Issues page if not yet complete. 

Screenshots for the change:

<img width="913" alt="screen shot 2017-10-08 at 10 49 31 am" src="https://user-images.githubusercontent.com/2702479/31318395-40beaa0e-ac17-11e7-9c27-91674a44de90.png">
