### PR TITLE
docker: use alpine, fix #189

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM node:6
+FROM node:6-alpine
 
 WORKDIR /app
 
-RUN useradd -ms /bin/bash octocat
-RUN chown octocat:octocat /app
+RUN adduser -D octocat && \
+    chown octocat:octocat /app
 USER octocat
 
 # With this npm install will only ever be run when building if the application's package.json changes!
 COPY package.json /app
 
-RUN npm install -g yarn && yarn install --production
+# The latest offical nodejs image already includes yarn.
+RUN yarn install --production --pure-lockfile
 
 COPY . /app
 


### PR DESCRIPTION
Fixes issue #189

Changes:
* Use `node:6-alpine` as base image.
* Drop `npm install -g yarn` as `node:6-alpine` already provides it. ([Ref](https://github.com/nodejs/docker-node/blob/36585913a2776f7f72afcdbf0d39d54625716916/6.11/alpine/Dockerfile#L51-L67))

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17795845/31320472-b3f2beb2-aca7-11e7-8d20-f3776509c3dc.png)
