### PR TITLE
Disable spellcheck on username field

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -2,7 +2,7 @@
 
 <div class="tc pt4">
     <form action="/" class="center h2 w-30-ns w-60-m w-80 flex" method="get">
-        <input class="bn br--left br1 ph2 flex-auto" type="text" name="username" placeholder="GitHub username" value="{{ username }}">
+        <input class="bn br--left br1 ph2 flex-auto" type="text" name="username" placeholder="GitHub username" value="{{ username }}" spellcheck="false">
         <button class="bg-orange bn br--right br1 pv0 ph3 pointer white" type="submit">Check</button>
     </form>
 </div>


### PR DESCRIPTION
Disables spellcheck on username field to avoid the annoying (and ugly) squiggly red line. Tested on chrome.
![screenshot 1](https://user-images.githubusercontent.com/16392483/31325267-cdd36462-ad06-11e7-80ba-d7978c5dc293.png)