### PR TITLE
config: upgrade dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "body-parser": "^1.15.1",
     "compression": "^1.6.2",
-    "dotenv": "^2.0.0",
+    "dotenv": "^4.0.0",
     "express": "^4.13.4",
     "express-flash": "0.0.2",
     "express-handlebars": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,9 +344,9 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-dotenv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
 ee-first@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
In dotenv 2.0.0, it throws an error when `.env` file is not found, even if the env we wanted were already specified via shell.
```plain
$ GITHUB_TOKEN=xxxxxxxx node .
{ Error: ENOENT: no such file or directory, open '.env'
    at Object.fs.openSync (fs.js:653:18)
    at Object.fs.readFileSync (fs.js:554:33)
    at Object.config (/home/xxx/hacktoberfest-checker/node_modules/dotenv/lib/main.js:30:37)
    at Object.<anonymous> (/home/xxx/hacktoberfest-checker/index.js:15:8)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Function.Module.runMain (module.js:665:10) errno: -2, code: 'ENOENT', syscall: 'open', path: '.env' }
Express server listening on port 5000
```

In dotenv 4.0.0, the error is written to `error` property of the return value instead of throwing it. ([Ref](https://github.com/motdotla/dotenv#config))
```plain
$ GITHUB_TOKEN=xxxxxxxx node .
Express server listening on port 5000
```

This patch is significant for Docker environment as `.env` is not included in the image by default.