### PR TITLE
3rd star background should blend on the section size

### DIFF
--- a/public/css/stars.css
+++ b/public/css/stars.css
@@ -27,6 +27,8 @@
 /*Had to add more stars and offset them*/
 
 .stars-three {
+    width: auto !important;
+    height: auto !important;
     top: 20%;
     left: 20%;
     background: transparent url(../img/stars.png) repeat top center;


### PR DESCRIPTION
Fixes issue #213

Changes: Because of the `top` and `left` style prop of the `.stars-three` class it extends page layout size that looks like on the issue. Instead of removing the said prop. I added a `width` and `height` to compensate the excess size. Thus work on several screen size.

Screenshots for the change:
![image](https://user-images.githubusercontent.com/1641990/31484390-bbfa5a94-af62-11e7-871d-1ee87902a020.png)

