### PR TITLE
Fix broken selector in Webkit-based browsers

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -159,7 +159,7 @@ function redirectToUserPage() {
 
 function saveUserPage() {
     // Save username into localStorage. Recall username by visiting /me.
-    localStorage.myGitHub = $('[name="username"').val();
+    localStorage.myGitHub = $('[name="username"]').val();
     // Provide some sort of visual feedback. Redirect to that page.
     window.location.href='/me';
 }


### PR DESCRIPTION
Fixes issue #235

Changes: Add closing brace to `name="username"` selector, so that WebKit no longer throws an exception ([the only browser to do so](https://www.reddit.com/r/firefox/comments/5nbmqi/on_handling_invalid_selector_strings:)).

Screenshots for the change: N/A