### PR TITLE
fix This is me button event handler

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -166,7 +166,7 @@ function saveUserPage() {
 
 $(document).on('ready', () => {
     // Save is bound to button press
-    $('#saveUser').on('click', () => saveUserPage());
+    $(document).on('click', '#saveUser', () => saveUserPage());
     // Works with /me or /me/
     if (window.location.pathname.startsWith('/me')) {
         redirectToUserPage();


### PR DESCRIPTION
Fixes issue #242 

Changes: The jquery event handler for the `This is me button` was changed, so that it works when the button was not existing at page load.
That solves the problem described in the mentioned issue

Screenshots for the change:
This is not a visual change...