### PR TITLE
Issue #254 - Correctly show PR amounts larger than 30

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -78,7 +78,8 @@ exports.index = (req, res) => {
 
 function findPrs(github, username) {
     return github.search.issues({
-        q: `-label:invalid+created:2017-09-30T00:00:00-12:00..2017-10-31T23:59:59-12:00+type:pr+is:public+author:${username}`
+        q: `-label:invalid+created:2017-09-30T00:00:00-12:00..2017-10-31T23:59:59-12:00+type:pr+is:public+author:${username}`,
+        per_page: 100
     })
         .then(prs => _.map(prs.data.items, event => {
             const repo = event.pull_request.html_url.substring(0, event.pull_request.html_url.search('/pull/'));


### PR DESCRIPTION
Fixes issue #254.

Changes: 
- Set the option per_page to 100, to show PR amounts larger than 30.


Screenshots for the change:
![image](https://user-images.githubusercontent.com/5196381/32014336-19ab66be-b9be-11e7-9f52-5de0a6a2718d.png)
