### PR TITLE
replace hardcoded year, show last year's result before October

### DIFF
--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -5,7 +5,7 @@
                 <a class="twitter-share-button white no-underline f6"
                     href="https://twitter.com/share"
                     data-size="large"
-                    data-text="My progress on hacktoberfest {{ prs.length }} / 5"
+                    data-text="My progress on hacktoberfest {{ prs.length }} / {{prAmount}}"
                     data-url="https://hacktoberfestchecker.herokuapp.com/?username={{username}}"
                     data-hashtags="hacktoberfest, hacktoberfestchecker">
                     Tweet
@@ -27,7 +27,7 @@
                 {{/if}}
             </div>
             <div class="flex flex-wrap  justify-center content-center flex-column">
-                <span class="db br2 f1 fw5 white w5">{{ prs.length }} / 5</span>
+                <span class="db br2 f1 fw5 white w5">{{ prs.length }} / {{prAmount}}</span>
                 <h3 class="mv1 fw3 light-gray">{{ statement }}</h3>
             </div>
         </div>


### PR DESCRIPTION
- use the current year, show last year's result before October 
- make background animation optional

This change removes the hardcoded year to search for PRs.
It also shows last year's result when checking before October.

The animation of the background (stars and clouds) is using a lot of CPU on the client machine.
The entire system becomes rather sluggish. This is not a great experience.

Animation is now off by default.
To activate it again, set the ENV variable ANIMATION to yes in the file .env
