### PR TITLE
Adds a counter for all PRs opened for Hacktoberfest 2018

### DIFF
--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -1,3 +1,9 @@
+{{#exists openedPrs}}
+<div class="f6 ph2 tc flex-none">
+    <p class="white">PRs already open for 2018: <strong>{{ openedPrs }}</strong>.</p>
+</div>
+{{/exists}}
+
 {{#exists prs}}
     <div class="tc white">
         <div class="pb4 flex justify-center">


### PR DESCRIPTION
Fixes issue #281 - It only appers in the screen after hit the search button.

Changes: Created a new request to search for issues with the params: type: pr, label: hacktoberfest, created: > 2018-09-30, created: < 2018-11-01. Extract data from the field `total_count`.

Screenshots for the change:
![selection_027](https://user-images.githubusercontent.com/2037349/46318722-dea26980-c5ad-11e8-8d06-f6f0921e7c41.png)

