### PR TITLE
Docker build: incorrect node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:8-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes issue #295 

Changes:
Fixed the node version by using `node: 8-apline` in the `Dockerfile`