### PR TITLE
Fix invisible avatar

### DIFF
--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -22,7 +22,7 @@
             <div class="mh3">
                 {{#if userImage}}
                     <a href = "https://github.com/{{username}}" target="_blank">
-                        <img id="userImage" alt="GitHub profile image for {{ username }}" class="tc br-100 w4 h4 bw2 b--solid b--near-white u-bgc--f4f4f4 overflow-hidden o-0 glow" src="{{userImage}}" />
+                        <img id="userImage" alt="GitHub profile image for {{ username }}" class="tc br-100 w4 h4 bw2 b--solid b--near-white u-bgc--f4f4f4 overflow-hidden dim" src="{{userImage}}" />
                     </a>
                 {{/if}}
             </div>


### PR DESCRIPTION
`.o-0 glow` makes the avatar invisible to start. I've replaced it with `.dim` to make the avatar visible (and match the screenshots) while still having a reactive component.

This will also be fixed by #299 ([line number](https://github.com/jenkoian/hacktoberfest-checker/pull/299/files#diff-506a5a0ceb78b91144bb23a742b4c7f8R25)).

Before:
![image](https://user-images.githubusercontent.com/451107/46427099-79b25500-c70e-11e8-8731-a4d21e8382a7.png)

After:
![image](https://user-images.githubusercontent.com/451107/46427130-8e8ee880-c70e-11e8-9b07-b2a3f2867c99.png)
