### PR TITLE
Use yarn in travis instead of npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ cache:
     - "node_modules"
   yarn: true
 
-before_script: npm install
-script: npm run eslint
+before_script: yarn install
+script: yarn run eslint


### PR DESCRIPTION
Fixes issue #312 

Changes: I've exchanged the usage of npm inside the `.travis.yml` so that travis is using yarn instead of npm.
