### PR TITLE
added MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hacktoberfest Checker
 
 [![Build Status](https://travis-ci.org/jenkoian/hacktoberfest-checker.svg?branch=master)](https://travis-ci.org/jenkoian/hacktoberfest-checker)
+![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 Useful checker web app to see how close you are to achieving the requirements for a free t-shirt as part of [Hacktoberfest](https://hacktoberfest.digitalocean.com/).
 


### PR DESCRIPTION
Changes: Added a MIT license badge next to the Travis CI badge.

Badge obtained from https://shields.io/#/

Screenshots for the change:

![image](https://user-images.githubusercontent.com/12476526/46447751-821f8580-c738-11e8-9fdc-6fca6276ed0a.png)