### PR TITLE
remove hardcoded hostname (link) for share buttons

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -177,5 +177,7 @@ $(document).on('ready', () => {
         var link = `${window.location.href.split('?')[0]}me`;
         document.getElementById('melink').innerHTML = link;
         document.getElementById('melink').href = link;
+        document.getElementById('twitter-share').setAttribute('data-url', window.location.href);
+        document.getElementById('fb-share').setAttribute('data-href', window.location.href);
     }
 });

--- a/views/partials/prs.hbs
+++ b/views/partials/prs.hbs
@@ -2,18 +2,18 @@
     <div class="text-center text-white">
         <div class="pb-8 flex justify-center">
             <div class="p-2">
-                <a class="bg-blue text-white rounded px-2 py-1 pointer text-white no-underline text-sm"
+                <a class="bg-blue text-white rounded px-2 py-1 pointer text-white no-underline text-sm" id="twitter-share"
                     href="https://twitter.com/share"
                     data-size="large"
                     data-text="My progress on hacktoberfest {{ prs.length }} / {{prAmount}}"
-                    data-url="https://hacktoberfestchecker.herokuapp.com/?username={{username}}"
+                    data-url="{{hostname}}/?username={{username}}"
                     data-hashtags="hacktoberfest, hacktoberfestchecker">
                     <i class="fab fa-twitter fa-lg"></i>
                     Tweet
                 </a>
             </div>
-            <div class="p-2"
-                data-href="https://hacktoberfestchecker.herokuapp.com/?username={{username}}"
+            <div class="p-2" id="fb-share"
+                data-href="{{hostname}}/?username={{username}}"
                 data-layout="button"
                 data-size="large">
                     <a class="fb-xfbml-parse-ignore bg-blue-dark text-white rounded px-2 py-1 pointer text-white no-underline text-sm" href="https://www.facebook.com/sharer/sharer.php">


### PR DESCRIPTION
The twitter and fb share buttons use a hardcoded link.
This change uses the actual hostname (and path) of the checker web site.