### PR TITLE
Add 'autocapitalize' and 'autocorrect' attributes to the input

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -3,7 +3,7 @@
 <div class="pb-4 md:pt-16">
     <p class="text-center text-white pb-2">{{ timemessage }}</p>
     <form action="/" class="flex h-8 mx-auto w-5/6 md:w-3/5 lg:w-1/3" method="get">
-        <input class="bn br--left rounded-l-sm px-2 flex-auto" type="text" name="username" aria-label="GitHub username" placeholder="GitHub username" value="{{ username }}" spellcheck="false">
+        <input class="bn br--left rounded-l-sm px-2 flex-auto" type="text" name="username" aria-label="GitHub username" placeholder="GitHub username" value="{{ username }}" spellcheck="false" autocapitalize="none" autocorrect="off">
         <button class="bn br--right bg-teal-lighter text-pink-darkest rounded-r-sm px-4 pointer text-white" type="submit">Check</button>
     </form>
 </div>


### PR DESCRIPTION
#### Issue
On an iOS device the mobile keyboard autocapitalises the first letter of your username and also tries to autocorrect any words. This is not ideal for GitHub user names.

This fix removes that and shows a lower case keyboard with no autocorrect.

#### Screenshot

##### Before
![before](https://user-images.githubusercontent.com/24863179/46906292-045a3780-cef9-11e8-9c5e-6722d6a9b22b.gif)

##### After
![after](https://user-images.githubusercontent.com/24863179/46906293-06bc9180-cef9-11e8-9286-98785d2749da.gif)

#### References
- [Touch Keyboard Types](https://baymard.com/labs/touch-keyboard-types)
- [MDN HTML <form> element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-autocapitalize)