### PR TITLE
Trim name input before storing in localstorage

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -159,7 +159,7 @@ function redirectToUserPage() {
 
 function saveUserPage() {
     // Save username into localStorage. Recall username by visiting /me.
-    localStorage.myGitHub = $('[name="username"]').val();
+    localStorage.myGitHub = $('[name="username"]').val().trim();
     // Provide some sort of visual feedback. Redirect to that page.
     window.location.href='./me';
 }


### PR DESCRIPTION
You can have a space in the name, and the page will work fine and load, but if you hit "this is me" it will save it with a space and then break.