### PR TITLE
Exclude PRs made to own repositories

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -147,7 +147,7 @@ function loadPrs(github, username) {
             searchyear = curyear - 1;
         }
         github.search.issues({
-            q: `-label:invalid+created:${searchyear}-09-30T00:00:00-12:00..${searchyear}-10-31T23:59:59-12:00+type:pr+is:public+author:${username}`,
+            q: `-label:invalid+created:${searchyear}-09-30T00:00:00-12:00..${searchyear}-10-31T23:59:59-12:00+type:pr+is:public+author:${username}+-user:${username}`,
             per_page: 100  // 30 is the default but this makes it clearer/allows it to be tweaked
         }, function(err, res) {
             if (err) {


### PR DESCRIPTION
**Ticket**: # none

#### Issue
The Hacktoberfest 2018 website, unlike in previous years, now hints that PRs towards own repositories will not be considered. (See [Rules section on the Hacktoberfest homepage](https://hacktoberfest.digitalocean.com/): *"The PR must contain commits you made yourself (not to your own repo)."*)

This PR adjusts the filters used in the GitHub API query (using the `user` qualifier) to exclude such PRs.

#### Usage Changes
No changes in usage, but the results now only contain PRs submitted to other users' and organizations' repositories.