### PR TITLE
Don't render number of PRs when count is 0

### DIFF
--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -108,7 +108,7 @@ export default class PullRequests extends Component {
           />
         </div>
         <div className="rounded mx-auto shadow overflow-hidden w-5/6 lg:w-1/2 mb-4">
-          {data.prs.length &&
+          {data.prs.length > 0 &&
             data.prs.map((pullRequest, i) => (
               <PullRequest pullRequest={pullRequest} key={i} />
             ))}


### PR DESCRIPTION
Fixes #340
**Ticket**: #340

#### Issue
This fixes the rendering of a `0` when there are no PRs.

#### Screenshot
![image](https://user-images.githubusercontent.com/107798/47732296-49da6c80-dc3c-11e8-9b7c-9001de178964.png)
