### PR TITLE
fix(#357): update `getResultMessage` for 2019

### DIFF
--- a/src/pages/User/components/PullRequests/UserInfo/ResultMessage/getResultMessage.js
+++ b/src/pages/User/components/PullRequests/UserInfo/ResultMessage/getResultMessage.js
@@ -3,7 +3,6 @@ import pullRequestAmount from '../../pullRequestAmount';
 const messages = [
   "It's not too late to start!",
   'Off to a great start, keep going!',
-  'Keep it up!',
   "Nice! Now, don't stop!",
   'So close!',
   'Way to go!',


### PR DESCRIPTION
### CHANGES

Hacktoberfest 2019 requires only 4 PRs. Dashboard messages updated to reflect this.