### PR TITLE
fix hacktoberfest label spacing

### DIFF
--- a/src/pages/User/components/PullRequests/PullRequest/index.js
+++ b/src/pages/User/components/PullRequests/PullRequest/index.js
@@ -6,7 +6,7 @@ import PullRequestInfo from './PullRequestInfo';
 const PullRequest = ({ pullRequest }) => (
   <div
     className={`bg-white leading-normal ${
-      pullRequest.has_hacktoberfest_label ? 'hacktoberfest' : ''
+      pullRequest.has_hacktoberfest_label ? 'hacktoberfest ' : ''
     }p-4 flex border-b border-grey break-words`}
   >
     <MergeStatus open={pullRequest.open} merged={pullRequest.merged} />


### PR DESCRIPTION
Hello! I opened issue #376 and I think I may found the problem. Patched it in this PR, hope everything is right.

When hacktoberfest label was present in PR, it was adding hacktoberfestp-4 to
div class. This PR fixes this by adding an extra space if 'hacktoberfest' label is present

fix #376 