### PR TITLE
Add glow around Hacktober title (Resolves Issue #379)

### DIFF
--- a/src/components/SiteTitle.js
+++ b/src/components/SiteTitle.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const SiteTitle = () => (
   <a className="no-underline text-center py-12 md:py-8" href="/">
-    <h1 className="text-blue-700 text-4xl md:text-6xl">
+    <h1 className="text-blue-700 text-4xl md:text-6xl text-glow">
       Hacktober<span className="text-mid-purple">fest</span>
     </h1>
     <small className="block text-yellow-400 text-base italic -mt-4 -mr-32 md:-mr-64">Checker</small>

--- a/src/index.css
+++ b/src/index.css
@@ -9746,7 +9746,7 @@ video {
 }
 
 .text-glow {
-  text-shadow: 0 0 2px #f2dd5e, 0 0 10px #f2dd5e, 0 0 35px #f2dd5e;
+  text-shadow: 0 0 2px #f2dd5e, 0 0 5px #f2dd5e, 0 0 25px #f2dd5e;
 }
 
 .hover\:text-transparent:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -9745,6 +9745,10 @@ video {
   color: #99a1b3;
 }
 
+.text-glow {
+  text-shadow: 0 0 2px #f2dd5e, 0 0 10px #f2dd5e, 0 0 35px #f2dd5e;
+}
+
 .hover\:text-transparent:hover {
   color: transparent;
 }


### PR DESCRIPTION
This is what it looks like with this CSS applied. What do you think?

<img width="546" alt="Screen Shot 2019-10-03 at 1 15 56 PM" src="https://user-images.githubusercontent.com/9082501/66149012-2bb18500-e5e0-11e9-9d4b-df6e14ddd0f2.png">
