### PR TITLE
feat: display PR count centered

### DIFF
--- a/src/pages/User/components/PullRequests/UserInfo/PullRequestCount.js
+++ b/src/pages/User/components/PullRequests/UserInfo/PullRequestCount.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import pullRequestAmount from '../pullRequestAmount';
 
 const PullRequestCount = ({ pullRequestCount }) => (
-  <span className="block text-5xl font-medium w-64">
+  <span className="block text-5xl font-medium w-64 self-center">
     <span className="text-yellow">{pullRequestCount}</span> /{' '}
     {pullRequestAmount}
   </span>


### PR DESCRIPTION
Thanks for this website!

I noticed that the PR count is not centered (specially in mobile)

**Actual**:
<img width="420" alt="image" src="https://user-images.githubusercontent.com/1694600/66533509-caeee480-ead8-11e9-8b74-00d4be01b879.png">

**Result**:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/1694600/66533543-e8bc4980-ead8-11e9-824c-c37fd1f2ae21.png">
