### PR TITLE
Added FAQ question about official "Profile" page showing progress

### DIFF
--- a/src/pages/Faq/data.js
+++ b/src/pages/Faq/data.js
@@ -9,6 +9,6 @@ export default [
     },
     {
         question: "Why is this project needed if Hacktoberfest's `Profile` now shows your progress?",
-        answer: "While it is true you can see your progress on Hacktoberfest's official website at https://hacktoberfest.digitalocean.com/profile this is still a really fun and rewarding project to work on. Plus we've done it for years before they ever thought to do it themselves :-)"
+        answer: "While it is true you can see your progress on Hacktoberfest's official website at https://hacktoberfest.digitalocean.com/profile it requires that you authenticate with Github. Hacktoberfest Checker doesn't require authentication so you can check on your own progress, or your mates progress, without needing to log in. Plus this is still a really fun and rewarding project to work on and we've done it for years before they ever thought to do it themselves :-)"
     }
 ]

--- a/src/pages/Faq/data.js
+++ b/src/pages/Faq/data.js
@@ -6,5 +6,9 @@ export default [
     {
         question: "Why do some PRs show outside of October?",
         answer: "If you've submitted a PR on the last day of September or the first day of November, there is a chance of it counting if it is October in any timezone."
+    },
+    {
+        question: "Why is this project needed if Hacktoberfest's `Profile` now shows your progress?",
+        answer: "While it is true you can see your progress on Hacktoberfest's official website at https://hacktoberfest.digitalocean.com/profile this is still a really fun and rewarding project to work on. Plus we've done it for years before they ever thought to do it themselves :-)"
     }
 ]


### PR DESCRIPTION
I've used Hacktoberfest Checker for several years now during Hacktoberfest and just found that they now offer a way you can see your progress on their own website. It made me as the question "Why is this project needed if Hacktoberfest's `Profile` now shows your progress?" so I thought I'd add that as a question to the new FAQ created under https://github.com/jenkoian/hacktoberfest-checker/issues/367