### PR TITLE
Fixed FAQ text overflow issue

### DIFF
--- a/src/pages/Faq/components/FaqEntry.js
+++ b/src/pages/Faq/components/FaqEntry.js
@@ -5,7 +5,7 @@ const FaqEntry = ({ data }) => {
     <div className="faqs shadow-lg flex text-mid-grey mb-6 p-4 break-words">
       <div className="pb-2 flex flex-wrap justify-left content-center rounded mx-auto my-5 overflow-hidden w-5/6 lg:w-100 ">
         <h3 className="text-light-blue mb-4">{data.question}</h3>
-        <p className="text-mid-grey">{data.answer}</p>
+        <p className="text-mid-grey overflow-auto">{data.answer}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
On the FAQ page, when viewing the page on mobile, text was flowing outside of its container. This commit resolves this issue.

**Before**
![Screenshot 2019-10-14 at 09 48 45](https://user-images.githubusercontent.com/5701722/66739329-603b0180-ee68-11e9-9caa-90a36cc55286.png)

**After**
![Screenshot 2019-10-14 at 09 49 22](https://user-images.githubusercontent.com/5701722/66739349-6a5d0000-ee68-11e9-9a3d-960e633ca3d0.png)
