### PR TITLE
Colour PR status icons

### DIFF
--- a/src/pages/User/components/PullRequests/PullRequest/MergeStatus.js
+++ b/src/pages/User/components/PullRequests/PullRequest/MergeStatus.js
@@ -6,7 +6,7 @@ const MergeStatus = ({ open, merged }) => (
     {open && (
       <svg
         aria-hidden="true"
-        fill="#39486E"
+        fill="#28a745"
         height="18"
         version="1.1"
         viewBox="0 0 12 16"
@@ -21,7 +21,7 @@ const MergeStatus = ({ open, merged }) => (
     {merged && (
       <svg
         aria-hidden="true"
-        fill="#39486E"
+        fill="#6f42c1"
         height="18"
         version="1.1"
         viewBox="0 0 12 16"
@@ -36,7 +36,7 @@ const MergeStatus = ({ open, merged }) => (
     {!open && !merged && (
       <svg
         aria-hidden="true"
-        fill="#39486E"
+        fill="#cb2431"
         height="18"
         version="1.1"
         viewBox="0 0 12 16"


### PR DESCRIPTION
I thought it may be a nice idea to make the status of each PR more obvious by adding some colour to the PR status icons.

**Screenshot:**
![Screenshot 2019-10-17 at 14 38 10](https://user-images.githubusercontent.com/5701722/67014317-8c66b480-f0ec-11e9-8b8b-e5c16e5e371f.png)

Thanks!