### PR TITLE
Fixed text overflowing on mobile

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -163,3 +163,14 @@ a:hover {
   content: "\f099";
   vertical-align: inherit;
 }
+
+
+/* Stopping URL going off page on smaller screens */
+.saveUser {
+  word-wrap: break-word
+}
+
+/* Changed size as div wasnt accounting for the ofset of icon on samller screens, causing text to overflow out of the div */
+.content-size {
+  width: 90%;
+}


### PR DESCRIPTION
- Stopped sharing URL overflowing

- Added '**.content-size**' to stop text overflowing in result boxes though needs adding to the element