### PR TITLE
Improve website footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -13,7 +13,7 @@ const Footer = () => (
       </a>
       .
     </p>
-    <div className="p-2 mt-4" id="faqs">
+    <div className="p-2 my-4" id="faqs">
       <a
         rel="noopener noreferrer"
         className="bg-mid-blue hover:bg-light-pink text-white hover:text-white px-2 py-1 pointer no-underline text-sm"

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -19,7 +19,7 @@ const Footer = () => (
         className="bg-mid-blue hover:bg-light-pink text-white hover:text-white px-2 py-1 pointer no-underline text-sm"
         href="/Faq"
       >
-      <i class="fas fa-question"/> FAQs
+      <i className="fas fa-question"/> FAQs
       </a>
     </div>
   </footer>


### PR DESCRIPTION
There should be an equal footer margin for both top and bottom, as that will make it look better and balanced on pages where the content is taller than the page height. 

Scrolling to the bottom will make the FAQ button seem too close to the end of the page without the bottom margin.

Also fixed a typo where `class` should be `className` instead.