### PR TITLE
Exclude draft and spam pull requests

### DIFF
--- a/api/controllers/pr/findPrs/index.js
+++ b/api/controllers/pr/findPrs/index.js
@@ -8,7 +8,14 @@ const loadPrs = require('./loadPrs');
 const findPrs = (github, username) => {
   return loadPrs(github, username)
     .then(pullRequestData =>
-      _.map(pullRequestData, event => {
+      pullRequestData.filter(event => {
+        const isInvalid = event.labels.some(label => {
+          return (label.name.toLowerCase() === 'invalid' ||
+                  label.name.toLowerCase() === 'spam');
+        });
+
+        return !isInvalid;
+      }).map(event => {
         const repo = event.pull_request.html_url.substring(
           0,
           event.pull_request.html_url.search('/pull/')

--- a/api/controllers/pr/findPrs/loadPrs.js
+++ b/api/controllers/pr/findPrs/loadPrs.js
@@ -3,7 +3,7 @@
 const getNextPage = require('./getNextPage');
 
 const buildQuery = (username, searchYear) =>
-  `-label:invalid+created:${searchYear}-09-30T00:00:00-12:00..${searchYear}-10-31T23:59:59-12:00+type:pr+is:public+author:${username}`;
+  `+created:${searchYear}-09-30T00:00:00-12:00..${searchYear}-10-31T23:59:59-12:00+type:pr+is:public+draft:false+author:${username}`;
 
 const loadPrs = (github, username) =>
   new Promise((resolve, reject) => {


### PR DESCRIPTION
According to FAQ, draft and spam pull requests should be ignored as well.

I tried `-label:invalid-label:spam` but it didn't work so I have to use `filter`.