### PR TITLE
add filter to check if repo has hacktoberfest label

### DIFF
--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -55,7 +55,7 @@ export default class PullRequests extends Component {
       .then(pullRequests =>
         this.setState({
           loading: false,
-          data: pullRequests
+          data: pullRequests.filter(pr=>pr.has_hacktoberfest_label)
         })
       )
       .catch(error =>


### PR DESCRIPTION
Not all PR's are eligible for hacktoberfest so I've added a filter to only count the PR's who's repo as hacktoberfest label in it