### PR TITLE
Filter PRs based on repo label

### DIFF
--- a/api/controllers/pr/findPrs/index.js
+++ b/api/controllers/pr/findPrs/index.js
@@ -30,7 +30,8 @@ const findPrs = (github, username) => {
             label => label.name.toLowerCase() === 'hacktoberfest-accepted'
           );
 
-          const twoWeeksOld = moment()
+          const twoWeeksOld = moment
+            .utc()
             .subtract(14, 'days')
             .startOf('day');
 
@@ -39,13 +40,13 @@ const findPrs = (github, username) => {
             number: event.number,
             open: event.state === 'open',
             repo_name: repo.replace('https://github.com/', ''),
-            repo_must_have_topic: moment(event.created_at).isAfter(
-              '2020-10-03T12:00:00.000Z'
-            ),
+            repo_must_have_topic: moment
+              .utc(event.created_at)
+              .isAfter('2020-10-03T12:00:00.000Z'),
             title: event.title,
             url: event.html_url,
-            created_at: moment(event.created_at).format('MMMM Do YYYY'),
-            is_pending: moment(event.created_at).isAfter(twoWeeksOld),
+            created_at: moment.utc(event.created_at).format('MMMM Do YYYY'),
+            is_pending: moment.utc(event.created_at).isAfter(twoWeeksOld),
             user: {
               login: event.user.login,
               url: event.user.html_url
@@ -144,7 +145,16 @@ const findPrs = (github, username) => {
           _.assign(pr, { approved })
         )
       );
-    });
+    })
+    .then(prs =>
+      prs.filter(
+        pr =>
+          !pr.repo_must_have_topic ||
+          pr.merged ||
+          pr.approved ||
+          pr.has_hacktoberfest_label
+      )
+    );
 };
 
 module.exports = findPrs;

--- a/api/controllers/pr/findPrs/index.js
+++ b/api/controllers/pr/findPrs/index.js
@@ -94,9 +94,12 @@ const findPrs = (github, username) => {
         );
     })
     .then(prs =>
-      prs.filter(
-        pr => !pr.repo_must_have_topic || pr.repo_has_hacktoberfest_topic
-      )
+      prs.filter(pr => {
+        // Operating under initial rules
+        if (!pr.repo_must_have_topic) return true;
+        // label OR topic
+        return pr.has_hacktoberfest_label || pr.repo_has_hacktoberfest_topic;
+      })
     )
     .then(prs => {
       const checkMergeStatus = _.map(prs, pr => {
@@ -147,13 +150,15 @@ const findPrs = (github, username) => {
       );
     })
     .then(prs =>
-      prs.filter(
-        pr =>
-          !pr.repo_must_have_topic ||
-          pr.merged ||
-          pr.approved ||
-          pr.has_hacktoberfest_label
-      )
+      prs.filter(pr => {
+        // Operating under initial rules
+        if (!pr.repo_must_have_topic) return true;
+        // label OR (topic AND (merged OR approved))
+        return (
+          pr.has_hacktoberfest_label ||
+          (pr.repo_has_hacktoberfest_topic && (pr.merged || pr.approved))
+        );
+      })
     );
 };
 

--- a/src/pages/Faq/data.js
+++ b/src/pages/Faq/data.js
@@ -2,7 +2,7 @@ export default [
   {
     question: "Why do some PRs have 'Pending' next to them?",
     answer:
-      "There is a grace period this year which means that a PR must be open (or merged) for at least a week in order to give maintainers the chance to mark issues as invalid. Therefore, the PR will be marked as 'Pending' until that grace period has expired."
+      "There is a grace period this year which means that a PR must be open (or merged/approved) for at least two weeks in order to give maintainers the chance to mark issues as invalid. Therefore, the PR will be marked as 'Pending' until that grace period has expired."
   },
   {
     question: 'Why do some PRs show outside of October?',

--- a/src/pages/User/components/PullRequests/PullRequest/PullRequestInfo.js
+++ b/src/pages/User/components/PullRequests/PullRequest/PullRequestInfo.js
@@ -21,6 +21,7 @@ PullRequestInfo.propTypes = {
     repo_name: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     created_at: PropTypes.string.isRequired,
+    is_pending: PropTypes.bool.isRequired,
     user: PropTypes.shape({
       login: PropTypes.string.isRequired,
       url: PropTypes.string.isRequired

--- a/src/pages/User/components/PullRequests/PullRequest/index.js
+++ b/src/pages/User/components/PullRequests/PullRequest/index.js
@@ -24,6 +24,7 @@ PullRequest.propTypes = {
     repo_has_hacktoberfest_topic: PropTypes.bool,
     title: PropTypes.string.isRequired,
     created_at: PropTypes.string.isRequired,
+    is_pending: PropTypes.bool.isRequired,
     has_hacktoberfest_label: PropTypes.bool.isRequired,
     open: PropTypes.bool.isRequired,
     merged: PropTypes.bool.isRequired,

--- a/src/pages/User/components/PullRequests/PullRequest/index.js
+++ b/src/pages/User/components/PullRequests/PullRequest/index.js
@@ -27,6 +27,7 @@ PullRequest.propTypes = {
     has_hacktoberfest_label: PropTypes.bool.isRequired,
     open: PropTypes.bool.isRequired,
     merged: PropTypes.bool.isRequired,
+    approved: PropTypes.bool.isRequired,
     user: PropTypes.shape({
       login: PropTypes.string.isRequired,
       url: PropTypes.string.isRequired

--- a/src/pages/User/components/PullRequests/PullRequest/index.js
+++ b/src/pages/User/components/PullRequests/PullRequest/index.js
@@ -20,6 +20,8 @@ PullRequest.propTypes = {
   pullRequest: PropTypes.shape({
     number: PropTypes.number.isRequired,
     repo_name: PropTypes.string.isRequired,
+    repo_must_have_topic: PropTypes.bool.isRequired,
+    repo_has_hacktoberfest_topic: PropTypes.bool,
     title: PropTypes.string.isRequired,
     created_at: PropTypes.string.isRequired,
     has_hacktoberfest_label: PropTypes.bool.isRequired,


### PR DESCRIPTION
Filters out PRs based on the [new rules](https://hacktoberfest.digitalocean.com/hacktoberfest-update), implemented by digitalocean/hacktoberfest#596.

These new rules are only applied to PRs created after `2020-10-03T12:00:00.000Z`.

***

For all PRs created after the above date, their repos labels are fetched and a `repo_has_hacktoberfest_topic` property is added to the PR, representing if the PR repo has the `hacktoberfest` topic.

Then PRs that are created after the above date and their repo doesn't have the `hacktoberfest` topic are filtered out.

***

The pending time has been increased from 7 days to 14 days.

The `has_hacktoberfest_label` now represents if the `hacktoberfest-accepted` label is present, instead of the `hacktoberfest` label.

***

I haven't used Lodash in a while, so hopefully I've implemented this in the proper style, I'm more familiar with the native variants of its methods.