### PR TITLE
[#440] Update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ cache:
   directories:
     - "node_modules"
 
-before_script: npm install
-script: npm run eslint
+before_script: npm ci
+script:
+  - npm run prettier


### PR DESCRIPTION
Changed `npm install` to `npm ci` to install dependencies based on lock file versions.

Changed `npm run eslint` to `npm run prettier` since `npm run eslint` was removed from package.json and was calling prettier to begin with.