### PR TITLE
Add "or tree" because Hacktoberfest 2020 reward can pick tee or plant a tree

### DIFF
--- a/src/components/RegisterReminder.js
+++ b/src/components/RegisterReminder.js
@@ -20,7 +20,7 @@ const RegisterReminder = () => (
       >
         register
       </a>{' '}
-      to be eligible for the tee!
+      to be eligible for the tee or tree!
     </span>
   </div>
 );


### PR DESCRIPTION
So, because Hacktoberfest 2020 reward is choice (pick a T-shirt or plant a tree), I decided to add "or tree" on register reminder. I choose "or tree" in order to unite rhyme [tee or tree]

Sorry if my PR is not much commit

Thank you