### PR TITLE
fix hover blue link on light mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -495,8 +495,8 @@ a:hover {
 
   a:hover {
     --text-opacity: 1;
-    color: #93c2db;
-    color: rgba(147, 194, 219, var(--text-opacity));
+    color: #7c99a9;
+    color: rgba(124, 153, 169, var(--text-opacity));
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -51,7 +51,7 @@ a:hover {
   }
 
   a:hover {
-    @apply text-light-blue;
+    @apply text-soft-blue;
   }
 }
 


### PR DESCRIPTION
When I hover the register link on the top of the page, it looks like disappear because it's the same color as the background color.
<img width="306" alt="Screenshot 2020-10-18 at 22 01 12" src="https://user-images.githubusercontent.com/50255944/96444615-218d1380-1241-11eb-9e89-d2fc1e0e9627.png">

Update with one of the light mode colors in tailwind config:
<img width="314" alt="Screenshot 2020-10-18 at 22 00 58" src="https://user-images.githubusercontent.com/50255944/96445147-ff47c580-1241-11eb-8170-a2c69a826d9f.png">


