### PR TITLE
Attempt to fix tailwind-gen for Windows users.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "tailwind-gen": "node ./node_modules/.bin/postcss ./src/style.css -o ./src/index.css",
-    "tailwind-gen-watch": "node ./node_modules/.bin/postcss --watch ./src/style.css -o ./src/index.css",
+    "tailwind-gen": "postcss ./src/style.css -o ./src/index.css",
+    "tailwind-gen-watch": "postcss --watch ./src/style.css -o ./src/index.css",
     "prettier": "prettier --check \"{src,api}/**/*.js\"",
     "prettier-fix": "prettier --write \"{src,api}/**/*.js\""
   },


### PR DESCRIPTION
If this still doesn't work we could try and test `npx tailwindcss build -o src/index.css`