### PR TITLE
update create date check for hacktoberfest2021

### DIFF
--- a/api/controllers/pr/findPrs/github/index.js
+++ b/api/controllers/pr/findPrs/github/index.js
@@ -39,7 +39,7 @@ const findPrs = (github, username) => {
             repo_name: repo.replace('https://github.com/', ''),
             repo_must_have_topic: moment
               .utc(event.created_at)
-              .isAfter('2020-10-03T12:00:00.000Z'),
+              .isAfter('2021-09-30T10:00:00.000Z'),
             title: event.title,
             url: event.html_url,
             created_at: moment.utc(event.created_at).format('MMMM Do YYYY'),

--- a/api/controllers/pr/findPrs/gitlab/index.js
+++ b/api/controllers/pr/findPrs/gitlab/index.js
@@ -39,7 +39,7 @@ const findPrs = (gitlab, username) => {
             repo_name: repo.replace('https://gitlab.com/', ''),
             repo_must_have_topic: moment
               .utc(event.created_at)
-              .isAfter('2020-10-03T12:00:00.000Z'),
+              .isAfter('2021-09-30T10:00:00.000Z'),
             title: event.title,
             url: event.web_url,
             created_at: moment.utc(event.created_at).format('MMMM Do YYYY'),


### PR DESCRIPTION
Updated the `created_at.isAfter()` PR checks to work for the 2021 version of Hacktoberfest