### PR TITLE
Remove unneeded Fragments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import GithubCorner from './components/GithubCorner';
@@ -12,7 +12,7 @@ import NotFound from './pages/NotFound';
 import Faq from './pages/Faq';
 
 const App = () => (
-  <Fragment>
+  <>
     <Helmet titleTemplate="%s | Hacktoberfest Checker" />
     <GithubCorner />
     <RegisterReminder />
@@ -38,7 +38,7 @@ const App = () => (
       </Router>
     </PageWrapper>
     <Footer />
-  </Fragment>
+  </>
 );
 
 export default App;

--- a/src/pages/Faq/index.js
+++ b/src/pages/Faq/index.js
@@ -1,20 +1,20 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import SiteTitle from '../../components/SiteTitle';
 import faqData from './data.js';
 import FaqEntry from './components/FaqEntry';
 
 const Faq = () => (
-  <Fragment>
+  <>
     <SiteTitle />
-    <h2 className="text-hack-fg light-mode:text-hack-dark-title text-center text-4xl font-extrabold">
+    <h2 className="text-4xl font-extrabold text-center text-hack-fg light-mode:text-hack-dark-title">
       FAQS
     </h2>
-    <div className="mx-auto w-5/6 lg:w-1/2 mb-4 mt-5">
+    <div className="w-5/6 mx-auto mt-5 mb-4 lg:w-1/2">
       {faqData.map((data) => (
         <FaqEntry key={data.question} data={data}></FaqEntry>
       ))}
     </div>
-  </Fragment>
+  </>
 );
 
 export default Faq;

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -1,12 +1,12 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import SiteTitle from '../../components/SiteTitle';
 import UsernameForm from '../../components/UsernameForm';
 
 const Home = () => (
-  <Fragment>
+  <>
     <SiteTitle />
     <UsernameForm />
-  </Fragment>
+  </>
 );
 
 export default Home;

--- a/src/pages/NotFound/index.js
+++ b/src/pages/NotFound/index.js
@@ -1,15 +1,15 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet';
 
 const NotFound = () => (
-  <Fragment>
+  <>
     <Helmet>
       <title>Page not found</title>
     </Helmet>
-    <h2 className="text-5xl md:text-xxl text-center text-hack-fg light-mode:text-hack-dark-title py-20">
+    <h2 className="py-20 text-5xl text-center md:text-xxl text-hack-fg light-mode:text-hack-dark-title">
       Oops!
     </h2>
-    <p className="text-center py-4 text-hack-fg light-mode:text-hack-dark-title">
+    <p className="py-4 text-center text-hack-fg light-mode:text-hack-dark-title">
       The page you are looking for does not exist.
     </p>
     <p className="text-center">
@@ -17,7 +17,7 @@ const NotFound = () => (
         Return to homepage
       </a>
     </p>
-  </Fragment>
+  </>
 );
 
 export default NotFound;

--- a/src/pages/User/components/PullRequests/index.js
+++ b/src/pages/User/components/PullRequests/index.js
@@ -1,5 +1,5 @@
 // Libraries
-import React, { Fragment, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 // Hooks
@@ -39,7 +39,7 @@ export default function PullRequests({ username }) {
   const isComplete = data.prs.length >= pullRequestAmount;
 
   return (
-    <Fragment>
+    <>
       <div className="text-center text-hack-fg">
         <ShareButtons username={username} pullRequestCount={data.prs.length} />
         <UserInfo
@@ -48,7 +48,7 @@ export default function PullRequests({ username }) {
           pullRequestCount={data.prs.length}
         />
       </div>
-      <div className="mx-auto w-5/6 lg:w-1/2 mb-4">
+      <div className="w-5/6 mx-auto mb-4 lg:w-1/2">
         {data.prs.length > 0 &&
           data.prs.map((pullRequest, i) => (
             <PullRequest pullRequest={pullRequest} key={i} />
@@ -56,7 +56,7 @@ export default function PullRequests({ username }) {
       </div>
       {!isComplete && <IssuesLink />}
       <MeLinkInfo username={username} />
-    </Fragment>
+    </>
   );
 }
 

--- a/src/pages/User/index.js
+++ b/src/pages/User/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
@@ -11,7 +11,7 @@ const User = () => {
   let { username } = useParams();
 
   return (
-    <Fragment>
+    <>
       <Helmet>
         <title>{username}</title>
       </Helmet>
@@ -19,7 +19,7 @@ const User = () => {
       <UsernameForm username={username} />
       <PullRequests username={username} />
       <UserShare />
-    </Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
There's a [shorter syntax](https://reactjs.org/docs/fragments.html#short-syntax) to write Fragments that do not require keys or attributes, like the ones used in this codebase. 

Also, some Tailwind classes have beer reordered automatically in those files with the [Headwind extension for VSCode](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind), a very useful one. 