### PR TITLE
Update hacktoberfest official webpage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://img.shields.io/github/workflow/status/jenkoian/hacktoberfest-checker/Build?logo=github)](https://github.com/jenkoian/hacktoberfest-checker/actions?query=workflow%3ABuild)
 ![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)
 
-Useful checker web app to see how close you are to achieving the requirements for a free t-shirt as part of [Hacktoberfest](https://hacktoberfest.digitalocean.com/).
+Useful checker web app to see how close you are to achieving the requirements for a free t-shirt as part of [Hacktoberfest](https://hacktoberfest.com/).
 
 [https://hacktoberfestchecker.jenko.me/](https://hacktoberfestchecker.jenko.me/)
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -8,7 +8,7 @@ const Footer = () => (
     <p className="text-hack-fg light-mode:text-hack-dark-title">
       Disclaimer: This site is fan made and not affiliated with{' '}
       <a
-        href="https://hacktoberfest.digitalocean.com/"
+        href="https://hacktoberfest.com/"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/components/RegisterReminder.js
+++ b/src/components/RegisterReminder.js
@@ -9,7 +9,7 @@ const RegisterReminder = () => (
     <span className="text-md leading-tight ml-4 mr-16 md:mr-8">
       Remember to{' '}
       <a
-        href="https://hacktoberfest.digitalocean.com/profile"
+        href="https://hacktoberfest.com/profile"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/pages/Faq/data.js
+++ b/src/pages/Faq/data.js
@@ -13,6 +13,6 @@ export default [
     question:
       "Why is this project needed if Hacktoberfest's `Profile` now shows your progress?",
     answer:
-      "While it is true you can see your progress on Hacktoberfest's official website at https://hacktoberfest.digitalocean.com/profile it requires that you authenticate with Github/Gitlab. Hacktoberfest Checker doesn't require authentication so you can check on your own progress, or your mates progress, without needing to log in. Plus this is still a really fun and rewarding project to work on and we've done it for years before they ever thought to do it themselves :-)",
+      "While it is true you can see your progress on Hacktoberfest's official website at https://hacktoberfest.com/profile it requires that you authenticate with Github/Gitlab. Hacktoberfest Checker doesn't require authentication so you can check on your own progress, or your mates progress, without needing to log in. Plus this is still a really fun and rewarding project to work on and we've done it for years before they ever thought to do it themselves :-)",
   },
 ];


### PR DESCRIPTION
Replace outdated official Hacktoberfest URLs and linking to the new domain instead (https://hacktoberfest.com)