### PR TITLE
bugfix: remove whitespaces from username input field

### DIFF
--- a/src/components/UsernameForm/index.js
+++ b/src/components/UsernameForm/index.js
@@ -15,7 +15,7 @@ export default function UsernameForm(props) {
   const navigate = useNavigate();
 
   const handleUsernameChange = useCallback(
-    (e) => setUsername(e.target.value.trim()),
+    (e) => setUsername(e.target.value),
     []
   );
 
@@ -28,9 +28,9 @@ export default function UsernameForm(props) {
       }
 
       if (props.onCheckUser) {
-        props.onCheckUser(username);
+        props.onCheckUser(username.trim());
       } else {
-        const userUrl = getUserUrl(username);
+        const userUrl = getUserUrl(username.trim());
         navigate(userUrl);
       }
     },

--- a/src/components/UsernameForm/index.js
+++ b/src/components/UsernameForm/index.js
@@ -15,7 +15,7 @@ export default function UsernameForm(props) {
   const navigate = useNavigate();
 
   const handleUsernameChange = useCallback(
-    (e) => setUsername(e.target.value),
+    (e) => setUsername(e.target.value.trim()),
     []
   );
 


### PR DESCRIPTION
Possible solution to fix #709 

Do you think this solution is a little user hostile? 
Would it be better to apply the trim() method only onSubmit to all the usages of state `username` thereafter? 

Thank you. 
