### PR TITLE
fix: Change back to 1 week review period

### DIFF
--- a/api/controllers/pr/findPrs/github/index.ts
+++ b/api/controllers/pr/findPrs/github/index.ts
@@ -64,7 +64,7 @@ export const findGithubPrs = async (github: Octokit, username: string) => {
           (label) => label.name.toLowerCase() === 'hacktoberfest-accepted'
         );
 
-        const twoWeeksOld = moment.utc().subtract(14, 'days').startOf('day');
+        const weekOld = moment.utc().subtract(7, 'days').startOf('day');
 
         return {
           has_hacktoberfest_label: hacktoberFestLabels,
@@ -77,7 +77,7 @@ export const findGithubPrs = async (github: Octokit, username: string) => {
           title: event.title,
           url: event.html_url,
           created_at: moment.utc(event.created_at).format('MMMM Do YYYY'),
-          is_pending: moment.utc(event.created_at).isAfter(twoWeeksOld),
+          is_pending: moment.utc(event.created_at).isAfter(weekOld),
           user: {
             login: event.user.login,
             url: event.user.html_url,

--- a/api/controllers/pr/findPrs/gitlab/index.ts
+++ b/api/controllers/pr/findPrs/gitlab/index.ts
@@ -68,7 +68,7 @@ export const findGitlabPrs = async (
         (label) => label.toLowerCase() === 'hacktoberfest-accepted'
       );
 
-      const twoWeeksOld = moment.utc().subtract(14, 'days').startOf('day');
+      const weekOld = moment.utc().subtract(7, 'days').startOf('day');
 
       return {
         has_hacktoberfest_label: hacktoberFestLabels,
@@ -82,7 +82,7 @@ export const findGitlabPrs = async (
         title: event.title,
         url: event.web_url,
         created_at: moment.utc(event.created_at).format('MMMM Do YYYY'),
-        is_pending: moment.utc(event.created_at).isAfter(twoWeeksOld),
+        is_pending: moment.utc(event.created_at).isAfter(weekOld),
         user: {
           login: event.author.username as string,
           url: event.author.web_url as string,

--- a/src/pages/Faq/data.js
+++ b/src/pages/Faq/data.js
@@ -2,7 +2,7 @@ export default [
   {
     question: "Why do some PRs have 'Pending' next to them?",
     answer:
-      "There is a grace period this year which means that a PR must be open (or merged/approved) for at least two weeks in order to give maintainers the chance to mark issues as invalid. Therefore, the PR will be marked as 'Pending' until that grace period has expired.",
+      "There is a grace period this year which means that a PR must be open (or merged/approved) for at least a week in order to give maintainers the chance to mark issues as invalid. Therefore, the PR will be marked as 'Pending' until that grace period has expired.",
   },
   {
     question: 'Why do some PRs show outside of October?',


### PR DESCRIPTION
The review period is 7 days this year. See [here](https://hacktoberfest.com/participation/#pr-mr-details).
However the review period starts when a PR/MR is merged, approved, or labeled as "hacktoberfest-accepted". I don't know how to determine the review period is ended or not.