### PR TITLE
Made search bar visible without scrolling 

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -20,7 +20,7 @@ const Navbar = () => {
 
   return (
     <>
-      <nav className="text-center pb-4">
+      <nav className="text-center pb-4 nav">
         {me && (
           <NavLink
             to="/me"
@@ -41,7 +41,7 @@ const Navbar = () => {
         </NavLink>
         <NavLink
           to="/friends"
-          className="p-2 border-b-2 border-transparent hover:border-hack-alt-logo light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title"
+          className="p-2 border-b-2 border-transparent hover:border-hack-alt-logo light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title "
           activeClassName="border-hack-logo"
         >
           Compare with friends

--- a/src/components/SiteTitle.js
+++ b/src/components/SiteTitle.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const SiteTitle = () => (
   <div className="text-center">
-    <a className="no-underline inline-block py-12 md:py-8" href="/">
+    <a className="no-underline inline-block py-12 md:py-8 title" href="/">
       <h1 className="text-hack-logo light-mode:text-hack-dark-title text-5xl md:text-7xl">
         hack
         <span className="block">tober</span>

--- a/src/components/UsernameForm/index.js
+++ b/src/components/UsernameForm/index.js
@@ -38,7 +38,7 @@ export default function UsernameForm(props) {
   );
 
   return (
-    <div className="pb-4 md:pt-16">
+    <div className="pb-4 md:pt-16 username-form">
       <TimeMessage />
       <form
         action="/"

--- a/src/index.css
+++ b/src/index.css
@@ -1098,3 +1098,23 @@ a:hover {
     color: rgb(43 53 49 / var(--tw-text-opacity));
   }
 }
+.nav {
+  padding: 0;
+}
+.title {
+  padding: 0.5rem 0;
+}
+.username-form {
+  padding-top: 1.6rem;
+}
+@media only screen and (max-width: 860px) {
+  .nav {
+    padding: 0.5rem;
+  }
+  .title {
+    padding: 3rem 0;
+  }
+  .username-form {
+    padding-top: 4rem;
+  }
+}


### PR DESCRIPTION
# I did some styling changes so that we could we the search bar directly when we open the website without scrolling.

###  Before: 
![Screenshot from 2022-10-10 08-11-03](https://user-images.githubusercontent.com/86418083/194791607-9c574e15-e012-4f63-b673-5e3a5cc21cd6.png)


### Now : 
![Screenshot from 2022-10-10 08-07-59](https://user-images.githubusercontent.com/86418083/194791640-8ea3893d-0170-4fe7-895b-91412f300ce9.png)

Sorry but I'm new and didn't understand how to close the issue, but this commit solves the issue of  no #719