### PR TITLE
Fix : Invisible word - "issues" was missing the className field

### DIFF
--- a/src/pages/User/components/PullRequests/IssuesLink.js
+++ b/src/pages/User/components/PullRequests/IssuesLink.js
@@ -4,7 +4,8 @@ const IssuesLink = () => (
   <div className="flex flex-wrap justify-center content-center text-center">
     <div className="text-hack-fg light-mode:text-hack-dark-title pb-4">
       Look at the following{' '}
-      <a className="light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title"
+      <a
+        className="light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title" 
         href="https://github.com/search?q=label:hacktoberfest+state:open+type:issue"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/pages/User/components/PullRequests/IssuesLink.js
+++ b/src/pages/User/components/PullRequests/IssuesLink.js
@@ -4,7 +4,7 @@ const IssuesLink = () => (
   <div className="flex flex-wrap justify-center content-center text-center">
     <div className="text-hack-fg light-mode:text-hack-dark-title pb-4">
       Look at the following{' '}
-      <a
+      <a className="light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title"
         href="https://github.com/search?q=label:hacktoberfest+state:open+type:issue"
         target="_blank"
         rel="noopener noreferrer"


### PR DESCRIPTION
Fix for #705 

The "issues" link was invisible due to a missing className field in the IssuesLink.js file

Added the following class field to the `<a>` tag- **`className="light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title"`**

![missingword](https://user-images.githubusercontent.com/40513836/196437062-2330415e-ce90-4b95-908f-288720fbf484.png)
![fixedmissingword](https://user-images.githubusercontent.com/40513836/196437469-161b2dfe-add7-4206-83f6-3f1077a93f6a.png)
