### PR TITLE
UX Enhancement : Added spans between navbar components

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -31,6 +31,7 @@ const Navbar = () => {
             Me
           </NavLink>
         )}
+        <span>|| </span>
         <NavLink
           to="/"
           isActive={isUserActive}
@@ -39,6 +40,7 @@ const Navbar = () => {
         >
           User
         </NavLink>
+        <span>|| </span>
         <NavLink
           to="/friends"
           className="p-2 border-b-2 border-transparent hover:border-hack-alt-logo light-mode:text-hack-dark-title light-mode:hover:text-hack-dark-title"


### PR DESCRIPTION
Hey Ian, I have added subtle spans `<span>'|| '</span>` between the navbar components (NavLink) - Me, User, Compare with friends that space them out a little and give them the resemblance of separate navbar buttons.  

![image](https://user-images.githubusercontent.com/40513836/197255215-275617bf-11a0-4583-8464-16fdaeb11cf1.png)
